### PR TITLE
Add reply to `telegram_post_multipart` and remove `wifi_config.rs.example`

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,7 +17,5 @@ jobs:
         with:
           default: true
           ldproxy: true
-      - name: copy config
-        run: cp src/wifi_config.rs.example src/wifi_config.rs
       - name: Run cargo check
         run: cargo check --bins --examples

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /target
 
 cfg.toml
+src/wifi_config.rs

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ After cloning the repo, download the esp32-camera component
 git submodule update --init
 ```
 
-then copy `src/wifi_config.rs.example` into `src/wifi_config.rs` and fill in the correct values
+Modify the file `src/wifi_config.rs` with the correct values
 
 ## Telegram bot
 

--- a/examples/telegram_bot/bot_api.rs
+++ b/examples/telegram_bot/bot_api.rs
@@ -60,6 +60,7 @@ pub fn telegram_post_multipart(
     data: &[u8],
     chat_id: i64,
     caption: Option<String>,
+    reply_to_message_id: Option<i32>,
 ) -> Result<Vec<u8>, EspBotError> {
     // 1. Create a new EspHttpConnection with default Configuration. (Check documentation)
     let config = Configuration::default();
@@ -74,6 +75,15 @@ pub fn telegram_post_multipart(
 
     let mut head = String::new();
     push_multipart_text_field(&mut head, boundary, "chat_id", &chat_id);
+
+    if let Some(reply_id) = reply_to_message_id {
+        push_multipart_text_field(
+            &mut head,
+            boundary,
+            "reply_parameters",
+            &format!(r#"{{"message_id":{}}}"#, reply_id),
+        );
+    }
 
     if let Some(caption) = caption.as_deref() {
         push_multipart_text_field(&mut head, boundary, "caption", caption);

--- a/examples/telegram_bot/main.rs
+++ b/examples/telegram_bot/main.rs
@@ -219,6 +219,7 @@ fn main() -> Result<()> {
                                 framebuffer.data(),
                                 message.chat.id,
                                 Some(caption),
+                                Some(message.message_id),
                             );
 
                             match res {

--- a/src/wifi_config.rs
+++ b/src/wifi_config.rs
@@ -1,0 +1,8 @@
+pub fn get_config() -> Config {
+    Config {
+        wifi_ssid: "YOUR_SSID",
+        wifi_psk: "YOUR_SSID_PASSWORD",
+        bot_token: "YOUR_BOT_TOKEN",
+        bot_owner_id: 1234567890,
+    }
+}

--- a/src/wifi_config.rs.example
+++ b/src/wifi_config.rs.example
@@ -1,8 +1,0 @@
-pub fn get_config() -> Config {
-    Config {
-        wifi_ssid: "my_wifi_ssid",
-        wifi_psk: "my_wifi_psk",
-        bot_token: "my_bot_token",
-        bot_owner_id: 1234567890,
-    }
-}


### PR DESCRIPTION
<img width="562" height="620" alt="2026-05-13-053331_hyprshot" src="https://github.com/user-attachments/assets/b861012c-7874-4ea4-97d9-6318e7dfc0da" />

- Reply to `/photo` instead of just sending the photo
- Remove `wifi_config.rs.example`

You should keep only `wifi_config.rs` and add it into `.gitignore` when the function is fixed (to prevent password leaking).
Add docs to `README.md` to guide users to edit `wifi_config.rs`